### PR TITLE
Fix print function issue

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,14 @@
 int run(const FooLang::CLIManager &cli, FooLang::Visitor &visitor)
 {
     auto jit = FooLang::JIT::create(visitor.module, visitor.llvm_context);
+    
+    jit->registerSymbols(
+        [&](llvm::orc::MangleAndInterner interner) {
+            llvm::orc::SymbolMap symbolMap;
+            // Add symbols here
+            symbolMap[interner("printf")] = llvm::JITEvaluatedSymbol::fromPointer(printf);
+            return symbolMap;
+        });
 
     auto entry = jit->lookup<int()>("main");
     if (!entry)


### PR DESCRIPTION
This code allows symbols to be explicitly registered in order for the JIT to access them. Registering the `printf` function as a symbol allows the FooLang `print` function to work.